### PR TITLE
TileDB; Better use of epiviz metadata; Measurement dictionary 

### DIFF
--- a/scripts/test_md-endpoint.py
+++ b/scripts/test_md-endpoint.py
@@ -4,7 +4,10 @@ emd_url = 'http://localhost/emd/api/v1/'
 
 mMgr = MeasurementManager()
 handler = create_fileHandler()
-mMgr.import_emd(emd_url, fileHandler=handler, listen=True)
+
+print(mMgr)
+print(mMgr.using_emd)
+mMgr.use_emd(emd_url, fileHandler=handler)
 
 app = setup_app(mMgr)
 

--- a/src/epivizfileserver/measurements/measurementManager.py
+++ b/src/epivizfileserver/measurements/measurementManager.py
@@ -196,6 +196,9 @@ class MeasurementSet(object):
         else:
             logging.debug("Tried to del ms {}: not found".format(key))
 
+    def get(self, key):
+        return self.measurements[key] if key in self.measurements else None
+
     def get_measurements(self):
         return self.measurements.values()
 
@@ -533,6 +536,11 @@ class MeasurementManager(object):
             new_records = self.emd_map.sync(self.measurements)
             self.import_records(new_records, fileHandler = self.emd_map.handler)
         return self.measurements.get_measurements()
+
+    def get_measurement(self, ms_id):
+        """Get a specific measurement
+        """
+        return self.measurements.get(ms_id)
 
     def get_genomes(self):
         """Get all available genomes

--- a/src/epivizfileserver/measurements/measurementManager.py
+++ b/src/epivizfileserver/measurements/measurementManager.py
@@ -8,6 +8,200 @@ import ujson
 import requests
 import pandas as pd
 
+from sanic.log import logger as logging
+
+class EMDMeasurementMap(object):
+    """
+    Manage mapping between measuremnts in EFS and metadata service
+
+    """
+    def __init__(self, url, fileHandler):
+        self.emd_endpoint = url
+        self.handler = fileHandler
+
+        # collection records from emd
+        self.collections = dict()
+
+        # map { emd id => efs measurement id }
+        self.measurement_map = dict()
+
+    def init(self):
+        logging.debug("Initializing from emd at {}".format(self.emd_endpoint))
+        self.init_collections()
+        records = self.init_measurements()
+        logging.debug("Done initializing from emd")
+        return records
+
+    def init_collections(self):
+        req_url = self.emd_endpoint + "/collections/"
+        logging.debug("Initializing collections from emd")
+        r = requests.get(req_url)
+        if r.status_code != 200:
+            raise Exception("Error initializing collections from emd {}: {}".format(req_url, r.text))
+
+        collection_records = r.json()    
+        for rec in collection_records:
+            # map database id to efs id
+            self.collections[rec['id']] = rec['collection_id']
+        logging.debug("Done initializing collections from emd")
+
+    def process_emd_record(self, rec):
+        # this is not elegant but... the epiviz-md api returns an 'id' which is the
+        # database id, we want the id of the record to be the 'measurement_id' as returned 
+        # by the epiviz-md api endpoint, so let's do that bit of surgery
+        # we keep a map between ids here
+        self.measurement_map[rec['id']] = rec['measurement_id']
+
+        rec['id'] = rec['measurement_id']
+        del rec['measurement_id']
+
+        collection_id = rec['collection_id']
+        del rec['collection_id']
+        collection_name = self.collections[collection_id]
+
+        current_annotation = rec['annotation']
+        if current_annotation is None:
+            current_annotation = { "collection": collection_name }
+        else:
+            current_annotation['collection'] = collection_name
+        rec['annotation'] = current_annotation
+
+    def init_measurements(self):
+        req_url = self.emd_endpoint + "/ms/"
+        logging.debug("Initializing measurements from emd")
+        r = requests.get(req_url)
+        if r.status_code != 200:
+            raise Exception("Error initializing measurements from emd {}: {}".format(req_url, r.text))
+
+        records = r.json()
+
+        for rec in records:
+            self.process_emd_record(rec)
+
+        logging.debug("Done initializing measurements")
+        return records
+
+    def sync(self, current_ms):
+        logging.debug("Syncing with emd at {}".format(self.emd_endpoint))
+
+        # this will remove deleted collections from
+        # the collection id map
+        new_collections = self.sync_collections()
+        new_records_from_collections = self.add_new_collections(new_collections)
+
+        # this will remove measurements in current_ms
+        # no longer in the emd db
+        new_measurements = self.sync_measurements(current_ms)
+        new_records = self.add_new_measurements(new_measurements)
+        logging.debug("Done syncing with emd")
+        return new_records_from_collections + new_records
+
+    def sync_collections(self):
+        req_url = self.emd_endpoint + "/collections/ids"
+        logging.debug("Syncing collections from emd")
+        r = requests.get(req_url)
+        if r.status_code != 200:
+            raise Exception("Error getting collection ids to sync from emd {}: {}".format(req_url, r.text))
+
+        emd_ids = r.json()
+        new_ids = list(set(emd_ids) - set(self.collections.values()))
+        del_ids = [ k for k, v in self.collections.items() if v not in emd_ids ]
+
+        for id in del_ids:
+            del self.collections[id]
+
+        return new_ids
+
+    def add_new_collections(self, new_collection_ids):
+        logging.debug("Adding new collections from emd")
+        all_records = []
+
+        for collection_id in new_collection_ids:
+            req_url = self.emd_endpoint + "/collections/" + collection_id
+            r = requests.get(req_url)
+            if r.status_code != 200:
+                raise Exception("Error getting collection with id {} from {}: {}".format(collection_id, req_url, r.text))
+
+            rec = r.json()
+
+            # map emd db id to efs id
+            self.collections[rec['id']] = rec['collection_id']
+            logging.debug("Added new collection {} from emd".format(rec['collection_id']))
+            
+            logging.debug("Adding measurements from collection {} from emd".format(rec['collection_id']))
+            req_url = self.emd_endpoint + "/collections/" + collection_id + "/ms"
+            r = requests.get(req_url)
+            if r.status_code != 200:
+                raise Exception("Error getting records for collection with id {} from {}: {}".format(collection_id, req_url, r.text))
+
+            records = r.json()
+            for rec in records:
+                self.process_emd_record(rec)
+
+            logging.debug("Done adding measurements from new collection")
+            all_records.extend(records)
+
+        logging.debug("Done adding new collections from emd")
+        return all_records
+
+    def sync_measurements(self, current_ms):
+        req_url = self.emd_endpoint + "/ms/ids"
+        logging.debug("Syncing measurements from emd")
+        r = requests.get(req_url)
+        if r.status_code != 200:
+            raise Exception("Error getting ms ids to sync from emd {}: {}".format(req_url, r.text))
+
+        ms_ids = r.json()
+        new_ids = list(set(ms_ids) - set(self.measurement_map.values()))
+        del_ids = [ k for k, v in self.measurement_map.items() if v not in ms_ids]
+
+        for id in del_ids:
+            ms_id = self.measurement_map[id]
+            del current_ms[ms_id]
+
+            if id in self.measurement_map:
+                del self.measurement_map[id]
+            else:
+                logging.debug("Tried to del ms map {}: not found".format(id))
+
+        return new_ids
+
+    def add_new_measurements(self, new_ms_ids):
+        logging.debug("Adding new ms from emd")
+        all_records = []
+        
+        for ms_id in new_ms_ids:
+            req_url = self.emd_endpoint + "/ms/" + ms_id
+            r = requests.get(req_url)
+            if r.status_code != 200:
+                raise Exception("Error getting ms with id {} from {}: {}".format(ms_id, req_url, r.text))
+
+            rec = r.json()
+            self.process_emd_record(rec)
+            all_records.append(rec)
+
+        logging.debug("Done adding new ms from emd")
+        return all_records
+
+class MeasurementSet(object):
+    def __init__(self):
+        self.measurements = {}
+
+    def append(self, ms):
+        self.measurements[ms.mid] = ms
+
+    def __delitem__(self, key):
+        if key in self.measurements:
+            del self.measurements[key]
+        else:
+            logging.debug("Tried to del ms {}: not found".format(key))
+
+    def get_measurements(self):
+        return self.measurements.values()
+
+    def get_mids(self):
+        return self.measurements.keys()
+    
 class MeasurementManager(object):
     """
     Measurement manager class
@@ -19,8 +213,9 @@ class MeasurementManager(object):
     def __init__(self):
         # self.measurements = pd.DataFrame()
         self.genomes = {}
-        self.measurements = []
+        self.measurements = MeasurementSet()
         self.emd_endpoint = None
+        self.emd_map = None
         self.tiledb = []
         self.stats = {
             "getRows": {},
@@ -81,7 +276,16 @@ class MeasurementManager(object):
         """ 
         measurements = []
 
-        for rec in records:
+        num_records = len(records)
+
+        for i, rec in enumerate(records):
+            format_args = { "i": i,
+                "num_records": num_records,
+                "datatype": rec['datatype'],
+                "file_type": rec['file_type']
+            }
+            logging.debug("Importing record {i}/{num_records} with datatype {datatype} and file type {file_type}".format(**format_args))
+
             isGene = False
             if "annotation" in rec["datatype"]:
                 isGene = True
@@ -114,7 +318,8 @@ class MeasurementManager(object):
                             isGenes=isGene, fileHandler=fileHandler
                         )
                     measurements.append(tempFileM)
-                    self.measurements.append(tempFileM)       
+                    self.measurements.append(tempFileM)
+                           
             elif rec.get("file_type").lower() in ["gwas", "bigbed"]:
                 anno = rec.get("annotation")
 
@@ -172,6 +377,7 @@ class MeasurementManager(object):
                 measurements.append(tempFile)
         return measurements
 
+    
     def get_from_emd(self, url=None):
         """Make a GET request to a metadata api
 
@@ -188,36 +394,54 @@ class MeasurementManager(object):
         req_url = url + "/collections/"
         r = requests.get(req_url)
         if r.status_code != 200:
-            raise Exception("Error importing collections {} from {}".format(r.text, req_url))
+            raise Exception("Error getting collections from emd {}".format(req_url))
 
         collection_records = r.json()
-
-        records = []
-
-        for collection_record in collection_records:
-            req_url = url + "/collections/{}/ms".format(collection_record['collection_id'])
-            r = requests.get(req_url)
-            if r.status_code != 200:
-                raise Exception("Error importing measurements from collection {} with url {}: {}".format(collection_record['collection_id'], req_url, r.text))
+        collections = {}
+    
+        for rec in collection_records:
+            collections[rec['id']] = rec['collection_id']
 
 
-            current_records = r.json()
+        req_url = url + "/ms/"
+        r = requests.get(req_url)
+        if r.status_code != 200:
+            raise Exception("Error importing measurements from collection {} with url {}: {}".format(collection_record['collection_id'], req_url, r.text))
 
-            # this is not elegant but... the epiviz-md api returns an 'id' which is the
-            # database id, we want the id of the record to be the 'measurement_id' as returned 
-            # by the epiviz-md api endpoint, so let's do that bit of surgery
-            for rec in current_records:
-                rec['id'] = rec.get('measurement_id')
-                del rec['measurement_id']
 
-                current_annotation = rec['annotation']
-                if current_annotation is None:
-                    current_annotation = { "collection": collection_record['collection_id'] }
-                else:
-                    current_annotation['collection'] = collection_record['collection_id']
+        records = r.json()
 
-            records += current_records
+        # this is not elegant but... the epiviz-md api returns an 'id' which is the
+        # database id, we want the id of the record to be the 'measurement_id' as returned 
+        # by the epiviz-md api endpoint, so let's do that bit of surgery
+        for rec in records:
+            rec['id'] = rec['measurement_id']
+            del rec['measurement_id']
+
+            collection_id = rec['collection_id']
+            del rec['collection_id']
+            collection_name = collections[collection_id]
+
+            current_annotation = rec['annotation']
+            if current_annotation is None:
+                current_annotation = { "collection": collection_name }
+            else:
+                current_annotation['collection'] = collection_name
+            rec['annotation'] = current_annotation
+
         return records
+
+    def use_emd(self, url, fileHandler=None):
+        """Delegate all getMeasurement calls to an epiviz-md metdata service api
+
+        Args:
+            url: the url of the epiviz-md api
+            fileHandler: an optional filehandler to use
+        """
+        logging.debug("Will be using emd api at {}".format(url))
+        self.emd_map = EMDMeasurementMap(url, fileHandler)
+        records = self.emd_map.init()
+        self.import_records(records, fileHandler = fileHandler)
 
     def import_emd(self, url, fileHandler=None, listen=True):
         """Import measurements from an epiviz-md metadata service api.
@@ -302,7 +526,13 @@ class MeasurementManager(object):
     def get_measurements(self):
         """Get all available measurements
         """
-        return self.measurements
+        if self.emd_map is not None:
+            # this will remove measurements in self.measureemnts
+            # that are not in the emd dbs any more
+            logging.debug("Getting mesurements. Cur ms {}".format(list(self.measurements.get_mids())))
+            new_records = self.emd_map.sync(self.measurements)
+            self.import_records(new_records, fileHandler = self.emd_map.handler)
+        return self.measurements.get_measurements()
 
     def get_genomes(self):
         """Get all available genomes
@@ -325,25 +555,3 @@ class MeasurementManager(object):
                 measurements.append(m)
         self.measurements.append(measurements)
         return measurements
-
-    def update_collections(self, handler=None):
-        result = []
-
-        if self.emd_endpoint is None:
-            return result, "Measurement manager is not listening"
-
-        try:
-            records = self.get_from_emd()
-        except Exception as e:
-            return result, "Error getting measurements from emd api {}".format(e)
-
-        current_measurement_ids = [ms.mid for ms in self.get_measurements()]
-        print(current_measurement_ids)
-        new_records = [rec for rec in records if rec.get('id') not in current_measurement_ids]
-
-        try:
-            self.import_records(new_records, fileHandler=handler)
-        except Exception as e:
-            return "", "Error inserting new measurements from emd api {}".format(e)
-
-        return new_records, ""

--- a/src/epivizfileserver/measurements/measurementManager.py
+++ b/src/epivizfileserver/measurements/measurementManager.py
@@ -98,6 +98,10 @@ class MeasurementManager(object):
                 samples = pd.read_csv(rec.get("url") + "/cols", sep="\t", index_col=0)
                 sample_names = samples.index.values
 
+                rows = pd.read_csv(rec.get("url") + "/rows", sep="\t", index_col=False, nrows=10)
+                metadata = rows.columns.values
+                metadata = [ m for m in metadata if m not in ['chr', 'start', 'end'] ]
+
                 for samp, (index, row) in zip(sample_names, samples.iterrows()):
                     anno = row.to_dict()
                     anno["_filetype"] = rec.get("file_type")
@@ -106,7 +110,7 @@ class MeasurementManager(object):
                     tempFileM = FileMeasurement(rec.get("file_type"), samp, 
                             samp + "_" + rec.get("name"), 
                             rec.get("url"), genome=tgenome, annotation=anno,
-                            metadata=rec.get("metadata"), minValue=0, maxValue=20,
+                            metadata=metadata, minValue=0, maxValue=20,
                             isGenes=isGene, fileHandler=fileHandler
                         )
                     measurements.append(tempFileM)

--- a/src/epivizfileserver/measurements/measurementManager.py
+++ b/src/epivizfileserver/measurements/measurementManager.py
@@ -96,9 +96,9 @@ class MeasurementManager(object):
             if rec.get("file_type") == "tiledb":
                 # its expression dataset 
                 samples = pd.read_csv(rec.get("url") + "/cols", sep="\t", index_col=0)
-                for index, row in samples.iterrows():
-                # for samp in sampels["samples"]:
-                    samp = row["samples"]
+                sample_names = samples.index.values
+
+                for samp, (index, row) in zip(sample_names, samples.iterrows()):
                     anno = row.to_dict()
                     anno["_filetype"] = rec.get("file_type")
                     for key in rec.get("annotation").keys():
@@ -106,7 +106,7 @@ class MeasurementManager(object):
                     tempFileM = FileMeasurement(rec.get("file_type"), samp, 
                             samp + "_" + rec.get("name"), 
                             rec.get("url"), genome=tgenome, annotation=anno,
-                            metadata=rec.get("metadata"), minValue=0, maxValue=5,
+                            metadata=rec.get("metadata"), minValue=0, maxValue=20,
                             isGenes=isGene, fileHandler=fileHandler
                         )
                     measurements.append(tempFileM)

--- a/src/epivizfileserver/parser/TileDB.py
+++ b/src/epivizfileserver/parser/TileDB.py
@@ -7,16 +7,33 @@ class TileDB(object):
     TileDB Class to parse only local tiledb files 
 
     Args:
-        file (str): local full path to a dataset tiledb_folder. This folder
-            should contain data.tiledb, rows and cols files
+        path (str): local full path to a dataset tiledb_folder. This folder
+            should contain data.tiledb, rows and cols files. See below for more detail.
         columns ([str]) : column names for various columns in file
+
+    Detail:
+        The tiledb_folder should contain:
+            'data.tiledb' directory - corresponds to the uri of a tiledb array. The tiledb array
+            must have a 'vals' attribute from which values are read. The array should have as many
+            rows as the number of lines in the 'rows' file, and as many columns as the number of
+            lines in the 'cols' file.
+
+            'rows' file - this is a tab-separated value file describing the rows of the tiledb array
+            it must have as many lines as rows in the tiledb file. There should be no index column in
+            this file (i.e., it is read with pandas.read_csv(..., sep='\t', index_col=False)). It must
+            have columns 'chr', 'start' and 'end'.
+
+            'cols' file - this is a tab-separated value file describing the columns of the tiledb array.
+            It must have as many files as columns in the tiledb file. Column names for the tiledb array
+            will be obtained from the first column in this file (i.e., iti is read with 
+            pandas.read_csv(..., sep='\t', index_col=0)). 
     """
-    def __init__(self, file, columns=None):
-        self.count = tiledb.open(file + "/data.tiledb", 'r')
-        self.rows = pd.read_csv(file + "/rows", sep="\t", index_col=0)
-        self.cols = pd.read_csv(file + "/cols", sep="\t", index_col=0)
-        if columns is None:
-            self.columns = self.cols["samples"].values
+    def __init__(self, path):
+        self.path = path
+        self.count = tiledb.open(path + "/data.tiledb", 'r')
+        self.rows = pd.read_csv(path + "/rows", sep="\t", index_col=False)
+        self.cols = pd.read_csv(path + "/cols", sep="\t", index_col=0)
+        self.columns = self.cols.index.values
 
     def getRange(self, chr, start = None, end = None, bins=2000, zoomlvl=-1, metric="AVG", respType = "DataFrame", treedisk=None):
         """Get data for a given genomic location
@@ -38,7 +55,7 @@ class TileDB(object):
         try:
             result_rows = self.rows[(self.rows["chr"] == chr) & (self.rows["start"] <= end) & (self.rows["end"] >= start)]
             indices = result_rows.index.values            
-            matrix = self.count[indices[0]:indices[-1]+1,] 
+            matrix = self.count[indices[0]:indices[-1]+1,]['vals'] 
 
             result_matrix = pd.DataFrame(matrix, index=indices, columns=self.columns)           
             result_merge = pd.concat([result_rows, result_matrix], axis=1)

--- a/src/epivizfileserver/server/__init__.py
+++ b/src/epivizfileserver/server/__init__.py
@@ -3,7 +3,7 @@ from sanic.log import logger as logging
 from ..handler import FileHandlerProcess
 # import asyncio
 import ujson
-from .request import create_request, StatusRequest, UpdateCollectionsRequest
+from .request import create_request, StatusRequest
 from sanic_cors import CORS, cross_origin
 import os
 import sys
@@ -91,7 +91,7 @@ async def setup_after_connection(app, loop):
     # init distributed client
     # cluster = LocalCluster(asynchronous=True, scheduler_port=8786, nanny=False, n_workers=2, 
     #         threads_per_worker=1)
-    logging.info("setting up dask client with scheduler", app.dask_scheduler)
+    logging.info("setting up dask client with scheduler {}".format(app.dask_scheduler))
     if app.dask_scheduler is None:
         app.client = await Client(asynchronous=True, nanny=False, loop=ioloop)
     else:
@@ -258,17 +258,3 @@ async def process_request(request, datasource):
         res["data"]["SD"] = (data["sumSquares"] + (data["count"] * (mean ** 2)) - 2 * mean * data["sum"])/data["count"]
 
     return response.json(res, status=200)
-
-@app.route("/updateCollections", methods=["POST"])
-async def process_request(request):
-    epiviz_request = UpdateCollectionsRequest(request)
-    result, error = await epiviz_request.update_collections(request.app.epivizMeasurementsManager, request.app.epivizFileHandler)
-    status_code = 201 if len(error) == 0 else 501
-        
-    return response.json({
-            "requestId": -1,
-            "type": "response",
-            "error": error,
-            "version": 5,
-            "data": result},
-        status = status_code)

--- a/src/epivizfileserver/server/request.py
+++ b/src/epivizfileserver/server/request.py
@@ -127,8 +127,8 @@ class MeasurementRequest(EpivizRequest):
                 result.get("datasourceId").append(rec.source)
                 result.get("defaultChartType").append("track")
                 result.get("id").append(rec.mid)
-                result.get("maxValue").append(rec.minValue)
-                result.get("minValue").append(rec.maxValue)
+                result.get("maxValue").append(rec.maxValue)
+                result.get("minValue").append(rec.minValue)
                 result.get("name").append(rec.name)
 
                 result_type = "feature"

--- a/src/epivizfileserver/server/request.py
+++ b/src/epivizfileserver/server/request.py
@@ -121,6 +121,7 @@ class MeasurementRequest(EpivizRequest):
         try:
             measurements = mMgr.get_measurements()
 
+            logging.debug("Formatting measurements to send response")
             for rec in measurements:
                 result.get("annotation").append(rec.annotation)
                 result.get("datasourceGroup").append(rec.mid)
@@ -328,15 +329,3 @@ class StatusRequest(EpivizRequest):
             logging.error("Status Request: %s" % (self.datasource), exc_info=True)
             # print("failed in req get_data", str(e))
             return 0, str(err) + " --- " + str(e)
-
-class UpdateCollectionsRequest(EpivizRequest):
-    def __init__(self, request):
-        super(UpdateCollectionsRequest, self).__init__(request)
-
-    async def update_collections(self, mMgr, fileHandler):
-        result = []
-        err = None
-
-        # TODO: this should be async
-        result, err = mMgr.update_collections(handler=fileHandler)
-        return result, str(err)

--- a/src/epivizfileserver/server/request.py
+++ b/src/epivizfileserver/server/request.py
@@ -183,7 +183,7 @@ class DataRequest(EpivizRequest):
         return params
 
     async def get_data(self, mMgr):
-        measurements = mMgr.get_measurements()
+        #measurements = mMgr.get_measurements()
         genomes = mMgr.get_genomes()
         result = None
         err = None
@@ -206,47 +206,53 @@ class DataRequest(EpivizRequest):
                 mMgr.stats["getRows"][self.params.get("datasource")]["count"] += 1
                 mMgr.stats["getRows"][self.params.get("datasource")]["sumSquares"] += ((end-start) ** 2)
             else:
-                for rec in measurements:
-                    if "getRows" in self.request.get("action"):
-                        if rec.mid == self.params.get("datasource"):
-                            logging.debug("Request processing: %s\t%s" % (self.request.get("requestId"), "getRows"))
-                            start = time.time()
-                            result, err = await rec.get_data(self.params.get("seqName"), 
-                                        int(self.params.get("start")), 
-                                        int(self.params.get("end")),
-                                        self.request.get("bins")
-                                    )
-                            end = time.time()
-                            if self.params.get("datasource") not in  mMgr.stats["getRows"]:
-                                mMgr.stats["getRows"][self.params.get("datasource")] = {"sum": 0, "count": 0, "sumSquares": 0}
+                if "getRows" in self.request.get("action"):
+                    ms_id = self.params.get("datasource")
+                    rec = mMgr.get_measurement(ms_id)
+                    if rec is not None:
+                        logging.debug("Request processing: %s\t%s" % (self.request.get("requestId"), "getRows"))
+                        start = time.time()
+                        result, err = await rec.get_data(self.params.get("seqName"), 
+                                    int(self.params.get("start")), 
+                                    int(self.params.get("end")),
+                                    self.request.get("bins")
+                                )
+                        end = time.time()
+                        if self.params.get("datasource") not in  mMgr.stats["getRows"]:
+                            mMgr.stats["getRows"][self.params.get("datasource")] = {"sum": 0, "count": 0, "sumSquares": 0}
 
-                            mMgr.stats["getRows"][self.params.get("datasource")]["sum"] += (end-start)
-                            mMgr.stats["getRows"][self.params.get("datasource")]["count"] += 1
-                            mMgr.stats["getRows"][self.params.get("datasource")]["sumSquares"] += ((end-start) ** 2)
-                            break
-                    else:
-                        if rec.mid in self.params.get("measurement"):
-                            # legacy support for browsers that do not send this param
-                            if "bins" not in self.request.keys():
-                                tbins = 400
-                            else:
-                                tbins = int(self.request.get("bins"))
+                        mMgr.stats["getRows"][self.params.get("datasource")]["sum"] += (end-start)
+                        mMgr.stats["getRows"][self.params.get("datasource")]["count"] += 1
+                        mMgr.stats["getRows"][self.params.get("datasource")]["sumSquares"] += ((end-start) ** 2)
 
-                            logging.debug("Request processing: %s\t%s" % (self.request.get("requestId"), "getValues"))
-                            start = time.time()
-                            result, err = await rec.get_data(self.params.get("seqName"), 
-                                        int(self.params.get("start")), 
-                                        int(self.params.get("end")),
-                                        tbins
-                                    )
-                            end = time.time()
-                            if self.params.get("measurement")[0] not in  mMgr.stats["getValues"]:
-                                mMgr.stats["getValues"][self.params.get("measurement")[0]] = {"sum": 0, "count": 0, "sumSquares": 0}
+                else:
+                    # requests are made for list of measurements, but
+                    # for the newer apps (with components) its a list with only
+                    # one item
+                    ms_ids = self.params.get("measurement")
+                    rec = mMgr.get_measurement(ms_ids[0]) if len(ms_ids) == 1 else None
 
-                            mMgr.stats["getValues"][self.params.get("measurement")[0]]["sum"] += (end-start)
-                            mMgr.stats["getValues"][self.params.get("measurement")[0]]["count"] += 1
-                            mMgr.stats["getValues"][self.params.get("measurement")[0]]["sumSquares"] += ((end-start) ** 2)
-                            break
+                    if rec is not None:
+                        # legacy support for browsers that do not send this param
+                        if "bins" not in self.request.keys():
+                            tbins = 400
+                        else:
+                            tbins = int(self.request.get("bins"))
+
+                        logging.debug("Request processing: %s\t%s" % (self.request.get("requestId"), "getValues"))
+                        start = time.time()
+                        result, err = await rec.get_data(self.params.get("seqName"), 
+                                    int(self.params.get("start")), 
+                                    int(self.params.get("end")),
+                                    tbins
+                                )
+                        end = time.time()
+                        if self.params.get("measurement")[0] not in  mMgr.stats["getValues"]:
+                            mMgr.stats["getValues"][self.params.get("measurement")[0]] = {"sum": 0, "count": 0, "sumSquares": 0}
+
+                        mMgr.stats["getValues"][self.params.get("measurement")[0]]["sum"] += (end-start)
+                        mMgr.stats["getValues"][self.params.get("measurement")[0]]["count"] += 1
+                        mMgr.stats["getValues"][self.params.get("measurement")[0]]["sumSquares"] += ((end-start) ** 2)
             
             # result = result.to_json(orient='records')
             if result is not None :

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -57,7 +57,7 @@ for rec in file_config:
     mMgr.measurements.append(tempFileM)
 
 def test_bigwig_measurement():
-    assert mMgr.measurements[0].get_data("1", 1, 1000)
+    assert mMgr.get_measurement('test-bw').get_data("1", 1, 1000)
 
 def test_bigbed_measurement():
-    assert mMgr.measurements[1].get_data("chr1", 1, 1000)
+    assert mMgr.get_measurement('test-bb').get_data("chr1", 1, 1000)


### PR DESCRIPTION
## TileDB

- rearrange the tiledb file data structure 
- grab metadata from rows file
- grab annotation from cols file

## Metadata catalog

- keep measurement records in sync with epiviz metadata service (http://github.com/epiviz/epiviz-md)
- this switches the `measurements` slot in `MeasurementManager` to a `MeasurementSet` (a dictionary)

## Use `MeasurementSet` for `getData` requests

- Find corresponding measurement in a getData request faster by using the measurement dictionary
